### PR TITLE
Argonaut theme: update cursor text color

### DIFF
--- a/themes/argonaut.yaml
+++ b/themes/argonaut.yaml
@@ -6,7 +6,7 @@ colors:
 
   # Cursor colors
   cursor:
-    text: '0xFF261E'
+    text: '0xEBEBEB'
     cursor: '0xFF261E'
 
   # Normal colors


### PR DESCRIPTION
The cursor and text color are the same, making it unreadable when highlighting text with the cursor. Thus I suggest to change the text color to be the same as foreground color (0xEBEBEB).