### PR TITLE
add a link to the default theme in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Collection of colorschemes for easy configuration of the [Alacritty terminal
 emulator].
 
+The default theme is [Tomorrow Night](themes/tomorrow_night.yaml).
+
 [Alacritty terminal emulator]: https://github.com/alacritty/alacritty
 
 ## Installation


### PR DESCRIPTION
found in https://github.com/alacritty/alacritty/blob/828fdab7470c8d16d2edbe2cec919169524cb2bb/alacritty.yml#L199

took me forever to find this, I wish it had been listed somewhere.