### PR TITLE
Explicitly specify import position

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mkdir -p ~/.config/alacritty/themes
 git clone https://github.com/alacritty/alacritty-theme ~/.config/alacritty/themes
 ```
 
-Add an import to your `alacritty.toml` (Replace `{theme}` with your desired
+Add an import to the top of your `alacritty.toml` (Replace `{theme}` with your desired
 colorscheme):
 
 ```toml


### PR DESCRIPTION
I'm not using `toml` that often and took me quite a while to understand that the import has to be at the top of the file (makes sense)

The thrown error was: 
```
Unused config key: import
```

Just wanted to propose this little addition to avoid having this issue in the future again :)