### PR TITLE
Update onedark theme to match existing colorscheme

### DIFF
--- a/themes/onedark.toml
+++ b/themes/onedark.toml
@@ -2,7 +2,7 @@
 
 # Default colors
 [colors.primary]
-background = '#1e2127'
+background = '#282c34'
 foreground = '#abb2bf'
 
 # Normal colors


### PR DESCRIPTION
Change background color to match schemes used on popular code editors like [nvim] and [helix]. This change allows a seamless transition from terminal to editor and vice-versa. This commit also changes the filename to match the standard used in the previously mentioned editors.

[nvim]: https://github.com/joshdick/onedark.vim
[helix]: https://github.com/helix-editor/helix/blob/master/runtime/themes/onedark.toml