### PR TITLE
Fix typo in gnome_terminal.toml

### DIFF
--- a/themes/gnome_terminal.toml
+++ b/themes/gnome_terminal.toml
@@ -18,7 +18,7 @@ white      = '#d0cfcc'
 
 # Bright colors
 [colors.bright]
-black      = '#535c64'
+black      = '#5e5c64'
 red        = '#f66151'
 green      = '#33d17a'
 yellow     = '#e9ad0c'


### PR DESCRIPTION
GNOME Terminal's black color is `#5e5c64`, not `#535c64`.

These are the official sources:
- https://gitlab.gnome.org/GNOME/gnome-terminal/-/blob/master/src/org.gnome.Terminal.gschema.xml?ref_type=heads#L323
- https://gitlab.gnome.org/GNOME/gnome-terminal/-/blob/master/src/terminal-profile-editor.cc?ref_type=heads#L208

I think it is a typo because the E key and the 3 key are located close together.