### PR TITLE
fix bright black color

### DIFF
--- a/themes/solarized_dark.toml
+++ b/themes/solarized_dark.toml
@@ -18,7 +18,7 @@ white   = '#eee8d5'
 
 # Bright colors
 [colors.bright]
-black   = '#002b36'
+black   = '#586e75'
 red     = '#cb4b16'
 green   = '#586e75'
 yellow  = '#657b83'


### PR DESCRIPTION
without the changes, the color is barely visible
![image](https://github.com/alacritty/alacritty-theme/assets/51183852/38df4131-2651-43c3-932a-2d3bb8976f81)

with the changes
![image](https://github.com/alacritty/alacritty-theme/assets/51183852/b0e67717-40cd-4a1b-9962-e935618346e2)

print_colors template
![image](https://github.com/alacritty/alacritty-theme/assets/51183852/36a72b31-85d3-41fd-b41d-eb867844aa67)

Edit*: i made a typo in the commit msg, one of the colors ends with 26, but both are 36 in the hex code.
