### PR TITLE
Auto theme switch based on system theme

### DIFF
--- a/AlacrittyAutoTheme.service
+++ b/AlacrittyAutoTheme.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Alacritty automated theme switching based on Gnome system theme
+Require=dbus.service
+After=dbus.service
+
+[Service]
+ExecStart=/bin/bash /home/%u/.config/alacritty/themes/AlacrittyAutoTheme.sh
+Type=simple
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/AlacrittyAutoTheme.sh
+++ b/AlacrittyAutoTheme.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+interface="org.freedesktop.portal.Settings"
+monitor_path="/org/freedesktop/portal/desktop"
+monitor_member="SettingChanged"
+count=0 #D-Bus fires the change event 4 times so we'll only act on it once
+
+dbus-monitor --profile "interface='$interface',path=$monitor_path,member=$monitor_member" |
+	while read line; do
+		let count++
+
+		if [ $count = 3 ]; then
+			theme="$(gsettings get org.gnome.desktop.interface color-scheme)"
+			if [[ "$theme" == "'prefer-dark'" ]]; then
+				#Need to set with full paths, goofy things are happening otherwise
+				echo "$(echo import = [ \'~/.config/alacritty/themes/dark_theme.toml\' ] > ~/.config/alacritty/themes/theme.toml)"
+			else
+				echo "$(echo import = [ \'~/.config/alacritty/themes/light_theme.toml\' ] > ~/.config/alacritty/themes/theme.toml)"
+			fi
+			count=0
+		fi 
+	done

--- a/README.md
+++ b/README.md
@@ -26,13 +26,23 @@ import = [
 ]
 ```
 
-### Automated theme switching based on System theme in Gnome
-Automated switching uses systemd on gnome by plugging into the dbus and then swithcing which theme file is being imported.
-
+### Automatically switch theme based on System Appearance
+Automatically switch themes based on the current System Appearance (light/dark mode). You can edit both the `light_theme.toml` and `dark-theme.toml` file and set it to one of the options from the themes directory (or paste in your color scheme directly in light/dark file) and include the following in your main `alacritty.toml` file:
+```toml
+import = [
+    "~/.config/alacritty/themes/theme.toml"
+]
+```
+Then we'll install the systemd service, by opening a terminal in this current folder and running the following:
 ``` sh
 cp ./AlacrittyAutoTheme.service ~/.config/systemd/user/
 systemctl --user enable AlacrittyAutoTheme.service
 systemctl --user start AlacrittyAutoTheme.service
+```
+That's it, now when you switch your system theme, all Alacritty windows will also switch the respective light/dark themes you picked.
+`NOTE`: This is dependent on Gnome and systemd. The script is designed to work as an user-space systemd service and supports Gnome (`gsettings`) desktop environments. However, you can use the `theme.toml` file setup to manually change which theme is active by:
+``` sh
+echo "import = [ '.~/.config/alacritty/themes/light_theme.toml' ]" > ./theme.toml
 ```
 
 ### Manual

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ import = [
 ]
 ```
 
+### Automated theme switching based on System theme in Gnome
+Automated switching uses systemd on gnome by plugging into the dbus and then swithcing which theme file is being imported.
+
+``` sh
+cp ./AlacrittyAutoTheme.service ~/.config/systemd/user/
+systemctl --user enable AlacrittyAutoTheme.service
+systemctl --user start AlacrittyAutoTheme.service
+```
+
 ### Manual
 
 To manually include a colorscheme in an existing `alacritty.toml`, you just need

--- a/dark_theme.toml
+++ b/dark_theme.toml
@@ -1,0 +1,1 @@
+import = [ '~/.config/alacritty/themes/themes/nord.toml' ]

--- a/light_theme.toml
+++ b/light_theme.toml
@@ -1,0 +1,1 @@
+import = [ '~/.config/alacritty/themes/themes/pencil_light.toml' ]

--- a/theme.toml
+++ b/theme.toml
@@ -1,0 +1,1 @@
+import = [ '~/.config/alacritty/themes/dark_theme.toml' ]


### PR DESCRIPTION
Hello! This isn't a new theme but a theme switcher.

I wanted to take advantage of the awesome TOML import function and automatically switch Alacritty's theme. This is achieved with a systemd service in the userspace that monitors dbus for Gnome settings change and then replaces the import command to point to relevant light/dark theme.

If this PR is not appropriate for Alacritty or this theme repo, please let me know and I'll make a standalone repo for it. Happy to receive feedback and make updates or for you to change anything you see fit.

Cheers,
Shom