### PR TITLE
docs(readme): specify import position inside alacritty.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mkdir -p ~/.config/alacritty/themes
 git clone https://github.com/alacritty/alacritty-theme ~/.config/alacritty/themes
 ```
 
-Add an import to your `alacritty.toml` (Replace `{theme}` with your desired
+Add an import at the top of your `alacritty.toml` (Replace `{theme}` with your desired
 colorscheme):
 
 ```toml


### PR DESCRIPTION
This would help those who, like me, fail to understand where to put the import directive.
I figured it out thanks to issue #77.