### PR TITLE
Changed solarized_dark background color according to vim solarized colorscheme.

### DIFF
--- a/themes/solarized_dark.toml
+++ b/themes/solarized_dark.toml
@@ -2,7 +2,7 @@
 
 # Default colors
 [colors.primary]
-background = '#002b36'
+background = '#002732'
 foreground = '#839496'
 
 # Normal colors


### PR DESCRIPTION
There was an issue with alacritty and vim bg colors. Alacritty's bg was a bit lighter than vim's variant:
<img width="519" alt="image" src="https://github.com/alacritty/alacritty-theme/assets/78883260/1cec3cc2-2acc-4b5f-b36f-ff433c1d912a">

After some investigations I found that vim's guibg is "#002732", not "#002b36" ([link to this line](https://github.com/ericbn/vim-solarized/blob/034333b1c8b42886e79dd30de458f16172d324ba/colors/solarized.vim#L223C68-L223C81)):
<img width="735" alt="image" src="https://github.com/alacritty/alacritty-theme/assets/78883260/dbf6f6f4-2d87-4fe1-9bc5-4da43cfaf449">

Now both background colors are the same in vim and alacritty:
<img width="415" alt="image" src="https://github.com/alacritty/alacritty-theme/assets/78883260/9cdbfa82-5e12-476f-858e-5ce081d222e0">

