### PR TITLE
Minor README edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mkdir -p ~/.config/alacritty/themes
 git clone https://github.com/alacritty/alacritty-theme ~/.config/alacritty/themes
 ```
 
-Add an import to your `alacritty.toml` (Replace `{theme}` with your desired
+Add an import to the **top** of your `alacritty.toml` (Replace `{theme}` with your desired
 colorscheme):
 
 ```toml


### PR DESCRIPTION
Failure to place the import at the top of alacritty.toml may reject the loading of the theme, causing a warning: "Unused config key: import". Fix: https://github.com/alacritty/alacritty/issues/6996#issuecomment-1902089267