### PR TITLE
Add instructions for configuration on old alacritty versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,19 @@ git clone https://github.com/alacritty/alacritty-theme ~/.config/alacritty/theme
 ```
 
 Add an import to your `alacritty.toml` (Replace `{theme}` with your desired
-colorscheme):
+colorscheme).
+
+For alacritty versions >= 0.14.0 use:
 
 ```toml
 [general]
+import = [
+    "~/.config/alacritty/themes/themes/{theme}.toml"
+]
+```
+
+For alacritty versions < 0.14.0 use:
+```toml
 import = [
     "~/.config/alacritty/themes/themes/{theme}.toml"
 ]


### PR DESCRIPTION
Alacritty versions before 0.14.0 did not have the config option `import` in the `general` section and moving it into one does not change the theme and results in this error:

> Unused config key: general

See the [0.14.0 changelog](https://alacritty.org/changelog_0_14_0.html)