### PR TITLE
Fixed gruvbox dark and light cursor color

### DIFF
--- a/themes/gruvbox_dark.toml
+++ b/themes/gruvbox_dark.toml
@@ -7,6 +7,14 @@ background = '#282828'
 # soft contrast background = = '#32302f'
 foreground = '#ebdbb2'
 
+[colors.cursor]
+text   = '#282828'
+cursor = '#928374'
+
+[colors.vi_mode_cursor]
+text   = '#282828'
+cursor = '#928374'
+
 # Normal colors
 [colors.normal]
 black   = '#282828'

--- a/themes/gruvbox_light.toml
+++ b/themes/gruvbox_light.toml
@@ -7,6 +7,14 @@ background = '#fbf1c7'
 # soft contrast background = = '#f2e5bc'
 foreground = '#3c3836'
 
+[colors.cursor]
+text   = '#fbf1c7'
+cursor = '#928374'
+
+[colors.vi_mode_cursor]
+text   = '#fbf1c7'
+cursor = '#928374'
+
 # Normal colors
 [colors.normal]
 black   = '#fbf1c7'


### PR DESCRIPTION
This PR sets Gruvbox cursor colors for light and dark themes. The effect is shown in a picture below.
Before
<img width="240" height="58" alt="image" src="https://github.com/user-attachments/assets/7c50de1a-6af9-40c1-997a-741f6afe89aa" />
After
<img width="240" height="58" alt="image" src="https://github.com/user-attachments/assets/b98d49eb-a19b-4f23-b229-bd2ee3f5942e" />
